### PR TITLE
have version in type names

### DIFF
--- a/RestApi.Test/ApiTests/ExampleV1Test.cs
+++ b/RestApi.Test/ApiTests/ExampleV1Test.cs
@@ -1,17 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using RestApi.Models.V1;
+using RestApi.Models;
 using RestApi.Test.Models;
 
-namespace RestApi.Test.V1
+namespace RestApi.Test.ApiTests
 {
     [TestFixture]
-    public class ExampleTest : TestBase
+    public class ExampleV1Test : TestBase
     {
         [TestCase("")]
         [TestCase("/")]
@@ -23,7 +21,7 @@ namespace RestApi.Test.V1
                 using (var stream = await client.OpenReadTaskAsync(
                     new Uri(SetUp.UrlToV1Example + route)))
                 {
-                    var data = await JsonSerializer.DeserializeAsync<WeatherForecast[]>(stream);
+                    var data = await JsonSerializer.DeserializeAsync<WeatherForecastV1[]>(stream);
 
                     Assert.That(data.Length, Is.EqualTo(5));
                 }
@@ -35,12 +33,12 @@ namespace RestApi.Test.V1
         {
             await CatchWebException(async () =>
             {
-                WeatherForecast[] data;
+                WeatherForecastV1[] data;
                 using (var client = new WebClient())
                 using (var stream = await client.OpenReadTaskAsync(
                     new Uri($"{SetUp.UrlToV1Example}/{date}")))
                 {
-                    data = await JsonSerializer.DeserializeAsync<WeatherForecast[]>(stream);
+                    data = await JsonSerializer.DeserializeAsync<WeatherForecastV1[]>(stream);
 
                     Assert.That(data.Length, Is.EqualTo(5));
                     Assert.That(data[0].Date, Is.EqualTo(dates[0]));
@@ -63,7 +61,7 @@ namespace RestApi.Test.V1
                 using (var stream = await client.OpenReadTaskAsync(
                     new Uri($"{SetUp.UrlToV1Example}/{date}")))
                 {
-                    var data = await JsonSerializer.DeserializeAsync<WeatherForecast[]>(stream);
+                    var data = await JsonSerializer.DeserializeAsync<WeatherForecastV1[]>(stream);
                 }
 
                 Assert.Fail("This test should have ended up with an error response.");

--- a/RestApi.Test/ApiTests/ExampleV2Test.cs
+++ b/RestApi.Test/ApiTests/ExampleV2Test.cs
@@ -4,13 +4,13 @@ using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using RestApi.Models.V2;
+using RestApi.Models;
 using RestApi.Test.Models;
 
-namespace RestApi.Test.V2
+namespace RestApi.Test.ApiTests
 {
     [TestFixture]
-    public class ExampleTest : TestBase
+    public class ExampleV2Test : TestBase
     {
         [TestCase("")]
         [TestCase("/20200303")]
@@ -22,7 +22,7 @@ namespace RestApi.Test.V2
                 using (var stream = await client.OpenReadTaskAsync(
                     new Uri(SetUp.UrlToV2Example + route)))
                 {
-                    var data = await JsonSerializer.DeserializeAsync<WeatherForecast[]>(stream);
+                    var data = await JsonSerializer.DeserializeAsync<WeatherForecastV2[]>(stream);
                 }
 
                 Assert.Fail("This test should have ended up with an error response.");
@@ -48,7 +48,7 @@ namespace RestApi.Test.V2
                 using (var stream = await client.OpenReadTaskAsync(
                     new Uri(SetUp.UrlToV2ExampleWF + route)))
                 {
-                    var data = await JsonSerializer.DeserializeAsync<WeatherForecast[]>(stream);
+                    var data = await JsonSerializer.DeserializeAsync<WeatherForecastV2[]>(stream);
 
                     Assert.That(data.Length, Is.EqualTo(5 * 3));
                 }
@@ -66,7 +66,7 @@ namespace RestApi.Test.V2
                 using (var stream = await client.OpenReadTaskAsync(
                     new Uri($"{SetUp.UrlToV2ExampleWF}?from={date}")))
                 {
-                    var data = await JsonSerializer.DeserializeAsync<WeatherForecast[]>(stream);
+                    var data = await JsonSerializer.DeserializeAsync<WeatherForecastV2[]>(stream);
 
                     Assert.That(data.Length, Is.EqualTo(5 * 3));
                     Assert.That(data.Min(d => d.Date),
@@ -86,7 +86,7 @@ namespace RestApi.Test.V2
                 using (var stream = await client.OpenReadTaskAsync(
                     new Uri($"{SetUp.UrlToV2ExampleWF}?from={date}")))
                 {
-                    var data = await JsonSerializer.DeserializeAsync<WeatherForecast[]>(stream);
+                    var data = await JsonSerializer.DeserializeAsync<WeatherForecastV2[]>(stream);
                 }
 
                 Assert.Fail("This test should have ended up with an error response.");
@@ -115,7 +115,7 @@ namespace RestApi.Test.V2
                 using (var stream = await client.OpenReadTaskAsync(
                     new Uri($"{SetUp.UrlToV2ExampleWF}/{area}?from={date}{(days == null ?  "" : $"&days={days}")}")))
                 {
-                    var data = await JsonSerializer.DeserializeAsync<WeatherForecast[]>(stream);
+                    var data = await JsonSerializer.DeserializeAsync<WeatherForecastV2[]>(stream);
 
                     Assert.That(data.Length, Is.EqualTo(days ?? 5));
                     Assert.That(data.Min(d => d.Date),
@@ -133,7 +133,7 @@ namespace RestApi.Test.V2
                 using (var stream = await client.OpenReadTaskAsync(
                     new Uri($"{SetUp.UrlToV2ExampleWF}/{area}?from={date}")))
                 {
-                    var data = await JsonSerializer.DeserializeAsync<WeatherForecast[]>(stream);
+                    var data = await JsonSerializer.DeserializeAsync<WeatherForecastV2[]>(stream);
                 }
                 Assert.Fail("This test should have ended up with an error response.");
             }
@@ -159,7 +159,7 @@ namespace RestApi.Test.V2
                 using (var stream = await client.OpenReadTaskAsync(
                     new Uri($"{SetUp.UrlToV2ExampleWF}/{area}?from={date}")))
                 {
-                    var data = await JsonSerializer.DeserializeAsync<WeatherForecast[]>(stream);
+                    var data = await JsonSerializer.DeserializeAsync<WeatherForecastV2[]>(stream);
                 }
 
                 Assert.Fail("This test should have ended up with an error response.");

--- a/RestApi/Controllers/ErrorController.cs
+++ b/RestApi/Controllers/ErrorController.cs
@@ -7,8 +7,7 @@ using NSwag.Annotations;
 namespace RestApi.Controllers
 {
     [ApiController]
-    [ApiVersion("1")]
-    [ApiVersion("2")]
+    [ApiVersionNeutral]
     [Route("api/[controller]")]
     [OpenApiIgnore]
     public class ErrorController : ControllerBase

--- a/RestApi/Controllers/ExampleV1Controller.cs
+++ b/RestApi/Controllers/ExampleV1Controller.cs
@@ -4,14 +4,16 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using RestApi.Models.V1;
+using NSwag.Annotations;
+using RestApi.Models;
 
-namespace RestApi.Controllers.V1
+namespace RestApi.Controllers
 {
     [ApiController]
     [ApiVersion("1")]
-    [Route("api/v{version:apiVersion}/[controller]")]
-    public partial class ExampleController : ControllerBase
+    [Route("api/v{version:apiVersion}/Example")]
+    [OpenApiTag("API Example: Weather Forecast")]
+    public partial class ExampleV1Controller : ControllerBase
     {
         private static readonly string[] Summaries = new[]
         {
@@ -20,13 +22,13 @@ namespace RestApi.Controllers.V1
 
         private readonly ILogger _logger;
 
-        public ExampleController(ILogger<ExampleController> logger)
+        public ExampleV1Controller(ILogger<ExampleV1Controller> logger)
         {
             _logger = logger;
         }
 
         [HttpGet("{date}")]
-        public virtual IEnumerable<WeatherForecast> Get([FromRoute] string date)
+        public IEnumerable<WeatherForecastV1> Get([FromRoute] string date)
         {
             DateTime baseDate = DateTime.UtcNow;
             if (date != null
@@ -42,17 +44,16 @@ namespace RestApi.Controllers.V1
 
             var random = new Random();
             return Enumerable.Range(0, 5)
-                .Select(index => new WeatherForecast
+                .Select(index => new WeatherForecastV1
                 {
                     Date = baseDate.AddDays(index).ToString("d MMM, yyyy"),
                     TemperatureC = random.Next(-20, 55),
                     Summary = Summaries[random.Next(Summaries.Length)],
-                })
-                .ToArray();
+                });
         }
 
-        [HttpGet()]
-        public virtual IEnumerable<WeatherForecast> Get()
+        [HttpGet]
+        public IEnumerable<WeatherForecastV1> Get()
             => Get(null);
     }
 }

--- a/RestApi/Controllers/ExampleV2Controller.cs
+++ b/RestApi/Controllers/ExampleV2Controller.cs
@@ -4,14 +4,16 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using RestApi.Models.V2;
+using NSwag.Annotations;
+using RestApi.Models;
 
-namespace RestApi.Controllers.V2
+namespace RestApi.Controllers
 {
     [ApiController]
     [ApiVersion("2")]
-    [Route("api/v{version:apiVersion}/[controller]")]
-    public partial class ExampleController : ControllerBase
+    [Route("api/v{version:apiVersion}/Example")]
+    [OpenApiTag("API Example: Weather Forecast")]
+    public partial class ExampleV2Controller : ControllerBase
     {
         private static readonly string[] Areas = new[]
         {
@@ -25,13 +27,13 @@ namespace RestApi.Controllers.V2
 
         private readonly ILogger _logger;
 
-        public ExampleController(ILogger<ExampleController> logger)
+        public ExampleV2Controller(ILogger<ExampleV2Controller> logger)
         {
             _logger = logger;
         }
 
         [HttpGet("WeatherForecast/{area}")]
-        public virtual IEnumerable<WeatherForecast> GetWeatherForecast(
+        public IEnumerable<WeatherForecastV2> GetWeatherForecast(
             [FromRoute] string area,
             [FromQuery] string from,
             [FromQuery] int? days = null)
@@ -62,19 +64,18 @@ namespace RestApi.Controllers.V2
 
             var random = new Random();
             return Enumerable.Range(0, days.Value)
-                .Select(index => areas.Select(a => new WeatherForecast
+                .Select(index => areas.Select(a => new WeatherForecastV2
                 {
                     Area = a,
                     Date = baseDate.AddDays(index),
                     TemperatureC = random.Next(-20, 55),
                     Summary = Summaries[random.Next(Summaries.Length)],
                 }))
-                .SelectMany(w => w)
-                .ToArray();
+                .SelectMany(w => w);
         }
 
         [HttpGet("WeatherForecast")]
-        public virtual IEnumerable<WeatherForecast> GetWeatherForecast(
+        public IEnumerable<WeatherForecastV2> GetWeatherForecast(
             [FromQuery] string from,
             [FromQuery] int? days)
             => GetWeatherForecast(null, from, days);

--- a/RestApi/Models/WeatherForecastV1.cs
+++ b/RestApi/Models/WeatherForecastV1.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Text.Json.Serialization;
+using NJsonSchema.Annotations;
 
-namespace RestApi.Models.V1
+namespace RestApi.Models
 {
-    public class WeatherForecast
+    [JsonSchema(name: "WeatherForecast")]
+    public class WeatherForecastV1
     {
         [JsonPropertyName("date")]
         public string Date { get; set; }

--- a/RestApi/Models/WeatherForecastV2.cs
+++ b/RestApi/Models/WeatherForecastV2.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Text.Json.Serialization;
+using NJsonSchema.Annotations;
 
-namespace RestApi.Models.V2
+namespace RestApi.Models
 {
-    public class WeatherForecast
+    [JsonSchema(name: "WeatherForecast")]
+    public class WeatherForecastV2
     {
         [JsonPropertyName("date")]
         public DateTime Date { get; set; }


### PR DESCRIPTION
rename types so as to have version in their name, rather than having version in namespace. With a support of Route, OpenApiTag and JsonSchema attribute, API and Swagger Doc will not be affected.