### PR TITLE
use namespace convention

### DIFF
--- a/RestApi.Test/V1/ExampleTest.cs
+++ b/RestApi.Test/V1/ExampleTest.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using RestApi.Models.V1;
+using RestApi.Api.V1.Models;
 using RestApi.Test.Models;
 
 namespace RestApi.Test.V1

--- a/RestApi.Test/V2/ExampleTest.cs
+++ b/RestApi.Test/V2/ExampleTest.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using RestApi.Models.V2;
+using RestApi.Api.V2.Models;
 using RestApi.Test.Models;
 
 namespace RestApi.Test.V2

--- a/RestApi/Api/Common/Controllers/ErrorController.cs
+++ b/RestApi/Api/Common/Controllers/ErrorController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using NSwag.Annotations;
 
-namespace RestApi.Controllers
+namespace RestApi.Api.Common.Controllers
 {
     [ApiController]
     [ApiVersion("1")]

--- a/RestApi/Api/V1/Controllers/ExampleController.cs
+++ b/RestApi/Api/V1/Controllers/ExampleController.cs
@@ -4,13 +4,17 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using RestApi.Models.V1;
+using NSwag.Annotations;
+using RestApi.Api.V1.Models;
 
-namespace RestApi.Controllers.V1
+namespace RestApi.Api.V1.Controllers
 {
+    // Version is determined by Namespace Convention, which is set up in Startup.cs
+    // See more details about the convention in https://github.com/microsoft/aspnet-api-versioning/wiki/API-Version-Conventions
+
     [ApiController]
-    [ApiVersion("1")]
     [Route("api/v{version:apiVersion}/[controller]")]
+    [OpenApiTag("API Example: Weather Forecast")]
     public partial class ExampleController : ControllerBase
     {
         private static readonly string[] Summaries = new[]

--- a/RestApi/Api/V1/Models/WeatherForecast.cs
+++ b/RestApi/Api/V1/Models/WeatherForecast.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Text.Json.Serialization;
 
-namespace RestApi.Models.V1
+namespace RestApi.Api.V1.Models
 {
     public class WeatherForecast
     {

--- a/RestApi/Api/V2/Controllers/ExampleController.cs
+++ b/RestApi/Api/V2/Controllers/ExampleController.cs
@@ -4,13 +4,17 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using RestApi.Models.V2;
+using NSwag.Annotations;
+using RestApi.Api.V2.Models;
 
-namespace RestApi.Controllers.V2
+namespace RestApi.Api.V2.Controllers
 {
+    // Version is determined by Namespace Convention, which is set up in Startup.cs
+    // See more details about the convention in https://github.com/microsoft/aspnet-api-versioning/wiki/API-Version-Conventions
+
     [ApiController]
-    [ApiVersion("2")]
     [Route("api/v{version:apiVersion}/[controller]")]
+    [OpenApiTag("API Example: Weather Forecast")]
     public partial class ExampleController : ControllerBase
     {
         private static readonly string[] Areas = new[]

--- a/RestApi/Api/V2/Models/WeatherForecast.cs
+++ b/RestApi/Api/V2/Models/WeatherForecast.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Text.Json.Serialization;
 
-namespace RestApi.Models.V2
+namespace RestApi.Api.V2.Models
 {
     public class WeatherForecast
     {

--- a/RestApi/Startup.cs
+++ b/RestApi/Startup.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Versioning.Conventions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -21,6 +22,7 @@ namespace RestApi
 
             services.AddApiVersioning(options =>
             {
+                options.Conventions.Add(new VersionByNamespaceConvention());
                 options.ReportApiVersions = true;
             });
 


### PR DESCRIPTION
restructure namespace conforming to the namespace convention, which is a built-in convention in ASP.NET API Versioning.

These changes conflict with the changes in #1. It needs to be decided which to take and which to discard.